### PR TITLE
Add requirements file and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ more advanced experiments.
 python3 demo.py
 ```
 
+## Installing dependencies
+
+All scripts rely only on the Python standard library on Linux and macOS. If
+you are running Windows, the `curses` module used by the snake game is not
+bundled with Python. Install the `windows-curses` package first or use the
+provided `requirements.txt` file:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## Playing the Snake game
 
 A small terminal-based snake game is provided in `snake_game.py`. Use the arrow
@@ -19,3 +30,7 @@ collides with the border or itself.
 ```bash
 python3 snake_game.py
 ```
+
+**Note**: The game requires a fully featured terminal that supports the
+`curses` library. In some minimal or web-based environments the game window may
+not render correctly or may fail to start.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Dependencies for optional features
+windows-curses; sys_platform == 'win32'


### PR DESCRIPTION
## Summary
- document installing `windows-curses` in README
- add a small `requirements.txt`

## Testing
- `python3 -m py_compile demo.py snake_game.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa1894968832e9ae117af57d1341f